### PR TITLE
feature/uniforms

### DIFF
--- a/examples/dear-imgui/source/app.d
+++ b/examples/dear-imgui/source/app.d
@@ -59,12 +59,21 @@ immutable char* fs_source = "
 	}
 ";
 
+struct ImguiUniform {
+
+	float[4][4][] ProjMtx;
+
+	@TextureUnit(0)
+	OpaqueTexture* texture;
+
+} // ImguiUniform
+
 alias ImguiShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [
 		AttribTuple("Position", 0),
 		AttribTuple("UV", 1),
 		AttribTuple("Color", 2)
-	], float[4][4][], "ProjMtx", Texture*, "Texture"
+	], ImguiUniform
 );
 
 struct ImVert {
@@ -313,7 +322,8 @@ struct ImguiContext {
 			
 					// temporary opaque texture
 					OpaqueTexture cur_texture = Texture.fromId(cast(uint)pcmd.TextureId);
-					(*device_).draw_offset(shader_, vao_, draw_params, pcmd.ElemCount, idx_buffer_offset, proj_data[], &cur_texture);
+					auto uniform_data = ImguiUniform(proj_data[], &cur_texture);
+					(*device_).draw_offset(shader_, vao_, draw_params, pcmd.ElemCount, idx_buffer_offset, uniform_data);
 					
 				}
 				

--- a/examples/font-rendering/source/app.d
+++ b/examples/font-rendering/source/app.d
@@ -45,10 +45,20 @@ struct Vertex4f {
 	alias coord this;
 } // Vertex4f
 
+struct TextUniform {
+
+	Mat4f[] projection;
+	float[4] colour;
+
+	@TextureUnit(0)
+	Texture* tex;
+
+} // TextUniform
+
 alias TextShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [
 		AttribTuple("coord", 0)
-	], Mat4f[], "projection", float[4], "colour", Texture*, "tex"
+	], TextUniform
 );
 
 @(DrawType.DrawArrays)
@@ -290,7 +300,8 @@ struct FontAtlas {
 		TextVao.update(vertices_, new_coords, DrawPrimitive.Triangles);
 		
 		// do the drawings
-		device.draw(shader_, vertices_, params, projection_data, to!GLColour(colour), &texture_);
+		auto text_uniform = TextUniform(projection_data, to!GLColour(colour), &texture_);
+		device.draw(shader_, vertices_, params, text_uniform);
 
 	} // renderText
 

--- a/examples/memory-saver/source/app.d
+++ b/examples/memory-saver/source/app.d
@@ -63,18 +63,31 @@ immutable char* tex_fs_shader = "
     }
 ";
 
+struct TriangleUniform {
+
+	float[4][4][] model;
+
+} // TriangleUniform
+
 alias TriangleShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [
 		AttribTuple("position", 0),
 		AttribTuple("colour", 1)
-	], float[4][4][], "model"
+	], TriangleUniform
 );
+
+struct TextureUniform {
+
+	@TextureUnit(0)
+	Texture* diffuse;
+
+} // TextureUniform
 
 alias TextureShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [
         AttribTuple("position", 0),
         AttribTuple("uv", 1)
-    ], Texture*, "diffuse"
+    ], TextureUniform
 );
 
 struct Vertex2f2f {
@@ -226,10 +239,12 @@ void main() {
 		transform.rotation.z += 0.01;
 
 		// render to texture, also clear with ze blau
-		frame_buffer.draw(triangle_shader, vao, params, [cast(float[4][4])transform.transform.ptr[0..16]]);
+		auto framebuf_uniform = TriangleUniform([cast(float[4][4])transform.transform.ptr[0..16]]);
+		frame_buffer.draw(triangle_shader, vao, params, framebuf_uniform);
 
 		// now render given texture, woo!
-		device.draw(texture_shader, rect_vao, params, &framebuffer_texture);
+		auto uniform_data = TextureUniform(&framebuffer_texture);
+		device.draw(texture_shader, rect_vao, params, uniform_data);
 
 
 		window.present();

--- a/examples/render-to-texture/source/app.d
+++ b/examples/render-to-texture/source/app.d
@@ -70,11 +70,18 @@ alias TriangleShader = Shader!(
 	]
 );
 
+struct TextureUniform {
+
+	@TextureUnit(0)
+	Texture* diffuse;
+
+} // TextureUniform
+
 alias TextureShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [
         AttribTuple("position", 0),
         AttribTuple("uv", 1)
-    ], Texture*, "diffuse"
+    ], TextureUniform
 );
 
 struct Vertex2f3f {
@@ -217,7 +224,8 @@ void main() {
 		frame_buffer.draw(triangle_shader, vao, params);
 
 		// now render given texture, woo!
-		device.draw(texture_shader, rect_vao, params, &framebuffer_texture);
+		auto uniform_data = TextureUniform(&framebuffer_texture);
+		device.draw(texture_shader, rect_vao, params, uniform_data);
 
 		window.present();
 

--- a/examples/textured-rectangle/source/app.d
+++ b/examples/textured-rectangle/source/app.d
@@ -40,11 +40,21 @@ immutable char* fs_shader = "
 
 alias Mat4f = float[4][4];
 
+struct TextureUniform {
+
+	float[2] offset;
+
+	@TextureUnit(0)
+	Texture* diffuse;
+
+} // TextureUniform
+
 alias TextureShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [
 		AttribTuple("position", 0),
 		AttribTuple("uv", 1)
-	], float[2], "offset", Texture*, "diffuse");
+	], TextureUniform
+);
 
 struct Vertex2f2f {
 
@@ -157,8 +167,8 @@ void main() {
 		// cornflower blue, of course
 		device.clearColour(0x428bca);
 
-		float[2] offset = [-0.5, -0.5];
-		device.draw(texture_shader, vao, params, offset, &texture);
+		auto uniform_data = TextureUniform([-0.5, -0.5], &texture);
+		device.draw(texture_shader, vao, params, uniform_data);
 
 		window.present();
 

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -1742,7 +1742,9 @@ void draw_with_offset(ShaderType, VertexArrayType, UniformTypes...)(ref ShaderTy
 	Renderer.bindVertexArray(vao);
 	Renderer.useProgram(shader.handle);
 
-	static assert(UniformTypes.length == 0 || is(UniformTypes[0] == ShaderType.UniformStruct));
+	static assert(!__traits(compiles, ShaderType.UniformStruct) && UniformTypes.length == 0
+			|| is(UniformTypes[0] == ShaderType.UniformStruct),
+			"uniform struct was either omitted on draw call or added when unnecessary!");
 
 	static if (UniformTypes.length == 1)
 	foreach (i, m; PODMembers!(UniformTypes[0])) with (shader) {

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -315,13 +315,13 @@ GLuint createShaderProgram(in GLuint[] shader_ids, in AttribTuple[] attribs) {
 } //createShaderProgram
 
 alias AttribTuple = Tuple!(string, "identifier", int, "offset");
-struct Shader(ShaderType[] shader_types, AttribTuple[] attributes, Uniforms...) {
+struct Shader(ShaderType[] shader_types, AttribTuple[] attributes, UniformStructType) {
 
 	import std.string : format;
-	alias Bindings = Uniforms;
+	alias UniformStruct = UniformStructType;
 
 	GLuint program_;
-	mixin(q{GLint[%d] uniforms_;}.format(Uniforms.length / 2));
+	mixin(q{GLint[%d] uniforms_;}.format(PODMembers!UniformStructType.length));
 
 	@disable this(this);
 	@disable ref Shader opAssign(ref Shader);
@@ -369,20 +369,16 @@ struct Shader(ShaderType[] shader_types, AttribTuple[] attributes, Uniforms...) 
 		buffer ~= q{
 			new_shader.program_ = createShaderProgram(shader_ids, attributes);
 
-			foreach (i, uniform; Uniforms) {
+			foreach (i, m; PODMembers!UniformStruct) {
 
-				// two for each iteration, type + string
-				static if (i % 2 != 0) {
-					continue;
-				} else {
-					GLint res = glGetUniformLocation(new_shader.program_, Uniforms[i+1].ptr);
-					if (res == -1) {
-						immutable string error = format("failed to get uniform location for: %s (maybe it was optimized out?)",
-								Uniforms[i+1].stringof);
-						assert(0, error);
-					}
-					new_shader.uniforms_[i/2] = res;
+				GLint res = glGetUniformLocation(new_shader.program_, m);
+
+				if (res == -1) {
+					immutable string error = format("failed to get uniform location for: %s (maybe it was optimized out?)", m);
+					assert(0, error);
 				}
+
+				new_shader.uniforms_[i] = res;
 
 			}
 		};
@@ -611,6 +607,14 @@ struct TextureParams {
 	int mipmap_base_level, mipmap_max_level;
 
 } // TextureParams
+
+struct TextureUnit_ {
+	uint unit;
+} // TextureUnit_
+
+@property TextureUnit(uint unit) {
+	return TextureUnit_(unit);
+} // TextureUnit
 
 struct Texture {
 
@@ -1680,7 +1684,7 @@ void clearColour(DeviceType)(ref DeviceType device, GLint rgb)
 } // clearColour
 
 nothrow @nogc
-void draw_offset(DeviceType, ShaderType, VertexArrayType, Args...)(ref DeviceType device, ref ShaderType shader, ref VertexArrayType vao, DrawParams params, uint vertex_count, ushort* offset, Args args)
+void draw_offset(DeviceType, ShaderType, VertexArrayType)(ref DeviceType device, ref ShaderType shader, ref VertexArrayType vao, ref DrawParams params, uint vertex_count, ushort* offset, ref ShaderType.UniformStruct uniform)
 	    if (isDevice!DeviceType) {
 
 		Renderer.setViewport(device.width, device.height);
@@ -1688,19 +1692,19 @@ void draw_offset(DeviceType, ShaderType, VertexArrayType, Args...)(ref DeviceTyp
 		static if (isFramebuffer!DeviceType) {
 
 			Renderer.bindFramebuffer(device.handle);
-			draw_with_offset(shader, vao, params, vertex_count, offset, args);
+			draw_with_offset(shader, vao, params, vertex_count, offset, uniform);
 
 		} else {
 
 			Renderer.bindFramebuffer(0);
-			draw_with_offset(shader, vao, params, vertex_count, offset, args);
+			draw_with_offset(shader, vao, params, vertex_count, offset, uniform);
 
 		}
 
 }
 
 nothrow @nogc
-void draw(DeviceType, ShaderType, VertexArrayType, Args...)(ref DeviceType device, ref ShaderType shader, ref VertexArrayType vao, DrawParams params, Args args)
+void draw(DeviceType, ShaderType, VertexArrayType, UniformType = ShaderType.UniformStruct)(ref DeviceType device, ref ShaderType shader, ref VertexArrayType vao, ref DrawParams params, ref UniformType uniform)
 	if (isDevice!DeviceType) {
 
 	Renderer.setViewport(device.width, device.height);
@@ -1708,143 +1712,115 @@ void draw(DeviceType, ShaderType, VertexArrayType, Args...)(ref DeviceType devic
 	static if (isFramebuffer!DeviceType) {
 
 		Renderer.bindFramebuffer(device.handle);
-		draw(shader, vao, params, args);
+		draw(shader, vao, params, uniform);
 
 	} else {
 
 		Renderer.bindFramebuffer(0);
-		draw(shader, vao, params, args);
+		draw(shader, vao, params, uniform);
 
 	}
 
 }
 
 nothrow @nogc
-void draw(ShaderType, VertexArrayType, Args...)(ref ShaderType shader, ref VertexArrayType vao, DrawParams params, Args args) {
-	draw_with_offset(shader, vao, params, cast(uint)vao.num_vertices_, cast(ushort*)0, args);
+void draw(ShaderType, VertexArrayType, UniformType = ShaderType.UniformStruct)(ref ShaderType shader, ref VertexArrayType vao, ref DrawParams params, ref UniformType uniform) {
+	draw_with_offset(shader, vao, params, cast(uint)vao.num_vertices_, cast(ushort*)0, uniform);
 } // draw
 
+alias Alias(alias Symbol) = Symbol;
+
 nothrow @nogc
-void draw_with_offset(ShaderType, VertexArrayType, Args...)(ref ShaderType shader, ref VertexArrayType vao, DrawParams params, uint vertex_count, ushort* offset, Args args) {
-
-	import std.string : format;
-
-	// type checking args
-	static assert(args.length == ShaderType.Bindings.length/2,
-		"length of args passed doesn't match length of ShaderType bindings!");
-
-	foreach (i, arg; Args) {
-		static if (i % 2 != 0) {
-			continue;
-		} else { // TODO: look at this.. :I
-			//static assert(is (arg : ShaderType.Bindings[i]),
-			//	"input type: %s does not match binding type: %s!".format(arg.stringof, ShaderType.Bindings[i].stringof));
-		}
-	}
+void draw_with_offset(ShaderType, VertexArrayType, UniformType = ShaderType.UniformStruct)(ref ShaderType shader, ref VertexArrayType vao, ref DrawParams params, uint vertex_count, ushort* offset, ref UniformType uniform) {
 
 	Renderer.bindVertexArray(vao);
 	Renderer.useProgram(shader.handle);
 
-	/**
-	 * this keeps track of active texture number, TODO: put this in the uniform struct instead, maybe something like
+	foreach (i, m; PODMembers!UniformType) with (shader) {
 
-		struct PassedData {
-
-			@TextureUnit(0)
-			Texture* texture_1;
-
-			@TextureUnit(1)
-			Texture* texture_2;
-
-		}
-
-	*/
-
-	uint current_texture = 0;
-
-	foreach (i, T; Args) with (shader) {
+		alias T = typeof(__traits(getMember, uniform, m));
 
 		/**
 		 * Vectors
 		*/
 
 		static if (is (T : float)) {
-			glUniform1f(uniforms_[i], args[i]);
+			glUniform1f(uniforms_[i], __traits(getMember, uniform, m));
 		} else static if (is (T : float[2])) {
-			glUniform2f(uniforms_[i], args[i][0], args[i][1]);
+			glUniform2f(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1]);
 		} else static if (is (T : float[3])) {
-			glUniform3f(uniforms_[i], args[i][0], args[i][1], args[i][2]);
+			glUniform3f(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1], __traits(getMember, uniform, m)[2]);
 		} else static if (is (T : float[4])) {
-			glUniform4f(uniforms_[i], args[i][0], args[i][1], args[i][2], args[i][3]);
+			glUniform4f(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1], __traits(getMember, uniform, m)[2], __traits(getMember, uniform, m)[3]);
 
 		} else static if (is (T : uint)) {
-			glUniform1ui(uniforms_[i], args[i]);
+			glUniform1ui(uniforms_[i], __traits(getMember, uniform, m));
 		} else static if (is (T : uint[2])) {
-			glUniform2ui(uniforms_[i], args[i][0], args[i][1]);
+			glUniform2ui(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1]);
 		} else static if (is (T : uint[3])) {
-			glUniform3ui(uniforms_[i], args[i][0], args[i][1], args[i][2]);
+			glUniform3ui(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1], __traits(getMember, uniform, m)[2]);
 		} else static if (is (T : uint[4])) {
-			glUniform4ui(uniforms_[i], args[i][0], args[i][1], args[i][2], args[i][3]);
+			glUniform4ui(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1], __traits(getMember, uniform, m)[2], __traits(getMember, uniform, m)[3]);
 
 		} else static if (is (T : int)) {
-			glUniform1i(uniforms_[i], args[i]);
+			glUniform1i(uniforms_[i], __traits(getMember, uniform, m));
 		} else static if (is (T : int[2])) {
-			glUniform2i(uniforms_[i], args[i][0], args[i][1]);
+			glUniform2i(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1]);
 		} else static if (is (T : int[3])) {
-			glUniform3i(uniforms_[i], args[i][0], args[i][1], args[i][2]);
+			glUniform3i(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1], __traits(getMember, uniform, m)[2]);
 		} else static if (is (T : int[4])) {
-			glUniform4i(uniforms_[i], args[i][0], args[i][1], args[i][2], args[i][3]);
+			glUniform4i(uniforms_[i], __traits(getMember, uniform, m)[0], __traits(getMember, uniform, m)[1], __traits(getMember, uniform, m)[2], __traits(getMember, uniform, m)[3]);
 
 		} else static if (is (T : float[1][])) {
-			glUniform1fv(uniforms_[i], args[i].length, cast(float*)args[i].ptr);
+			glUniform1fv(uniforms_[i], __traits(getMember, uniform, m).length, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[2][])) {
-			glUniform2fv(uniforms_[i], args[i].length, cast(float*)args[i].ptr);
+			glUniform2fv(uniforms_[i], __traits(getMember, uniform, m).length, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[3][])) {
-			glUniform3fv(uniforms_[i], args[i].length, cast(float*)args[i].ptr);
+			glUniform3fv(uniforms_[i], __traits(getMember, uniform, m).length, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[4][])) {
-			glUniform4fv(uniforms_[i], args[i].length, cast(float*)args[i].ptr);
+			glUniform4fv(uniforms_[i], __traits(getMember, uniform, m).length, cast(float*)__traits(getMember, uniform, m).ptr);
 
 		} else static if (is (T : uint[1][])) {
-			glUniform1uiv(uniforms_[i], args[i].length, cast(uint*)args[i].ptr);
+			glUniform1uiv(uniforms_[i], __traits(getMember, uniform, m).length, cast(uint*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : uint[2][])) {
-			glUniform2uiv(uniforms_[i], args[i].length, cast(uint*)args[i].ptr);
+			glUniform2uiv(uniforms_[i], __traits(getMember, uniform, m).length, cast(uint*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : uint[3][])) {
-			glUniform3uiv(uniforms_[i], args[i].length, cast(uint*)args[i].ptr);
+			glUniform3uiv(uniforms_[i], __traits(getMember, uniform, m).length, cast(uint*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : uint[4][])) {
-			glUniform4uiv(uniforms_[i], args[i].length, cast(uint*)args[i].ptr);
+			glUniform4uiv(uniforms_[i], __traits(getMember, uniform, m).length, cast(uint*)__traits(getMember, uniform, m).ptr);
 
 		} else static if (is (T : int[1][])) {
-			glUniform1iv(uniforms_[i], args[i].length, cast(int*)args[i].ptr);
+			glUniform1iv(uniforms_[i], __traits(getMember, uniform, m).length, cast(int*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : int[2][])) {
-			glUniform2iv(uniforms_[i], args[i].length, cast(int*)args[i].ptr);
+			glUniform2iv(uniforms_[i], __traits(getMember, uniform, m).length, cast(int*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : int[3][])) {
-			glUniform3iv(uniforms_[i], args[i].length, cast(int*)args[i].ptr);
+			glUniform3iv(uniforms_[i], __traits(getMember, uniform, m).length, cast(int*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : int[4][])) {
-			glUniform4iv(uniforms_[i], args[i].length, cast(int*)args[i].ptr);
+			glUniform4iv(uniforms_[i], __traits(getMember, uniform, m).length, cast(int*)__traits(getMember, uniform, m).ptr);
 
 		/**
 		 * Matrices
 		*/
 
 		} else static if (is (T : float[2][2][])) {
-			glUniformMatrix2fv(uniforms_[i], args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix2fv(uniforms_[i], __traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[3][3][])) {
-			glUniformMatrix3fv(uniforms_[i], args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix3fv(uniforms_[i], __traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[4][4][])) {
-			glUniformMatrix4fv(uniforms_[i], cast(int)args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix4fv(uniforms_[i], cast(int)__traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 
 		} else static if (is (T : float[2][3][])) {
-			glUniformMatrix2x3fv(uniforms_[i], args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix2x3fv(uniforms_[i], __traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[3][2][])) {
-			glUniformMatrix3x2fv(uniforms_[i], args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix3x2fv(uniforms_[i], __traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[2][4][])) {
-			glUniformMatrix2x4fv(uniforms_[i], args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix2x4fv(uniforms_[i], __traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[4][2][])) {
-			glUniformMatrix4x2fv(uniforms_[i], args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix4x2fv(uniforms_[i], __traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[3][4][])) {
-			glUniformMatrix3x4fv(uniforms_[i], args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix3x4fv(uniforms_[i], __traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 		} else static if (is (T : float[4][3][])) {
-			glUniformMatrix4x3fv(uniforms_[i], args[i].length, GL_FALSE, cast(float*)args[i].ptr);
+			glUniformMatrix4x3fv(uniforms_[i], __traits(getMember, uniform, m).length, GL_FALSE, cast(float*)__traits(getMember, uniform, m).ptr);
 
 		/**
 		 * Textures
@@ -1852,8 +1828,13 @@ void draw_with_offset(ShaderType, VertexArrayType, Args...)(ref ShaderType shade
 
 		} else static if (is (T : Texture*) || is(T : OpaqueTexture*)) {
 
+			import std.traits : getUDAs;
+
 			// currently just a single bind, think about this later
-			Renderer.bindTexture(args[i].handle, current_texture++);
+			alias texture_units = getUDAs!(__traits(getMember, uniform, m), TextureUnit_);
+			assert(texture_units.length == 1);
+
+			Renderer.bindTexture(__traits(getMember, uniform, m).handle, texture_units[0].unit);
 
 		}
 

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -1843,7 +1843,7 @@ void draw_with_offset(ShaderType, VertexArrayType, UniformTypes...)(ref ShaderTy
 
 			// currently just a single bind, think about this later
 			alias texture_units = getUDAs!(__traits(getMember, uniforms[0], m), TextureUnit_);
-			assert(texture_units.length == 1);
+			static assert(texture_units.length == 1, "expected exactly one @TextureUnit UDA on Texture type!");
 
 			Renderer.bindTexture(__traits(getMember, uniforms[0], m).handle, texture_units[0].unit);
 


### PR DESCRIPTION
We can now pass uniforms by a struct instead, allowing us to annotate data with UDAs, like textures now need a @TextureUnit UDA to specify which texture unit they should be bound to.

Deciding if this should have the possibility to also be a runtime parameter somehow is worth thinking about.
