### PR TITLE
feature/textures

### DIFF
--- a/examples/dear-imgui/source/app.d
+++ b/examples/dear-imgui/source/app.d
@@ -120,7 +120,7 @@ struct ImguiContext {
 
 		// graffix data
 		ImguiShader shader_;
-		Texture texture_;
+		Texture2D texture_;
 		ImguiVao vao_;
 
 		double time_;
@@ -253,7 +253,7 @@ struct ImguiContext {
 			filtering : TextureFiltering.Linear
 		};
 
-		Texture.create(texture_, pixels, width, height, tex_params);
+		auto tex_result = Texture2D.create(texture_, pixels, width, height, tex_params);
 		ImFontAtlas_SetTexID(io.Fonts, cast(void*)texture_.handle);
 
 	} // createFontTexture

--- a/examples/dear-imgui/source/app.d
+++ b/examples/dear-imgui/source/app.d
@@ -25,7 +25,7 @@ auto bindDelegate(T, string file = __FILE__, size_t line = __LINE__)(T t) if(isD
 
 } // bindDelegate (thanks Destructionator)
 
-immutable char* vs_source = "
+immutable char* vs_source = q{
 	#version 330 core
 
 	uniform mat4 ProjMtx;
@@ -42,9 +42,9 @@ immutable char* vs_source = "
 		Frag_Color = Color;
 		gl_Position = ProjMtx * vec4(Position.xy, 0, 1);
 	}
-";
+};
 
-immutable char* fs_source = "
+immutable char* fs_source = q{
 	#version 330 core
 
 	uniform sampler2D Texture_;
@@ -57,7 +57,7 @@ immutable char* fs_source = "
 	void main() {
 		Out_Color = Frag_Color * texture(Texture_, Frag_UV.st);
 	}
-";
+};
 
 struct ImguiUniform {
 

--- a/examples/font-rendering/source/app.d
+++ b/examples/font-rendering/source/app.d
@@ -51,7 +51,7 @@ struct TextUniform {
 	float[4] colour;
 
 	@TextureUnit(0)
-	Texture* tex;
+	Texture2D* tex;
 
 } // TextUniform
 
@@ -106,7 +106,7 @@ struct FontAtlas {
 
 		TextVao vertices_;
 		TextShader shader_;
-		Texture texture_;
+		Texture2D texture_;
 
 		CharacterInfo[96] chars_;
 
@@ -192,7 +192,7 @@ struct FontAtlas {
 			wrapping : TextureWrapping.ClampToEdge
 		};
 
-		auto texture_result = Texture.create(atlas.texture_, null, w, h, params);
+		auto texture_result = Texture2D.create(atlas.texture_, cast(ubyte*)null, w, h, params);
 
 		int x = 0; // current x position in the resulting texture to write to
 		for (uint i = 32; i < 128; ++i) {
@@ -316,7 +316,7 @@ void main() {
 
 	Window window;
 	auto result = Window.create(window, 640, 480);
-	auto device = Renderer.createDevice(&window.width, &window.height);
+	auto device = Renderer.createDevice(&window.width, &window.height, &window.present);
 
 	final switch (result) with (Window.Error) {
 
@@ -376,7 +376,7 @@ void main() {
 		Mat4f[1] projection_data = [transposed_projection];
 		text_atlas.renderText(device, projection_data[], "Hello, World!", window.width / 4, window.height / 2, 1.0f, 1.0f, 0xffa500);
 
-		window.present();
+		device.present();
 
 	}
 

--- a/examples/indexed/source/app.d
+++ b/examples/indexed/source/app.d
@@ -74,7 +74,7 @@ void main() {
 
 	Window window;
 	auto result = Window.create(window, 640, 480);
-	auto device = Renderer.createDevice(&window.width, &window.height);
+	auto device = Renderer.createDevice(&window.width, &window.height, &window.present);
 
 	final switch (result) with (Window.Error) {
 
@@ -137,7 +137,7 @@ void main() {
 		device.clearColour(0x428bca);
 		device.draw(triangle_shader, vao, params);
 
-		window.present();
+		device.present();
 
 	}
 

--- a/examples/indexed/source/app.d
+++ b/examples/indexed/source/app.d
@@ -8,7 +8,7 @@ import gland.util;
 import gland.win;
 import gland.gl;
 
-immutable char* vs_shader = "
+	immutable char* vs_shader = q{
 	#version 330
 
 	layout (location = 0) in vec2 position;
@@ -20,9 +20,9 @@ immutable char* vs_shader = "
 		gl_Position = vec4(position, 0.0, 1.0);
 		v_colour = colour;
 	}
-";
+};
 
-immutable char* fs_shader = "
+immutable char* fs_shader = q{
 	#version 330
 
 	in vec3 v_colour;
@@ -31,9 +31,7 @@ immutable char* fs_shader = "
 	void main() {
 		f_colour = vec4(v_colour, 1.0);
 	}
-";
-
-alias Mat4f = float[4][4];
+};
 
 alias TriangleShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [

--- a/examples/instancing/source/app.d
+++ b/examples/instancing/source/app.d
@@ -76,7 +76,7 @@ void main() {
 
 	Window window;
 	auto result = Window.create(window, 640, 480);
-	auto device = Renderer.createDevice(&window.width, &window.height);
+	auto device = Renderer.createDevice(&window.width, &window.height, &window.present);
 
 	final switch (result) with (Window.Error) {
 
@@ -137,7 +137,7 @@ void main() {
 		device.clearColour(0x428bca);
 		device.draw(instance_shader, vao, params);
 
-		window.present();
+		device.present();
 
 	}
 

--- a/examples/instancing/source/app.d
+++ b/examples/instancing/source/app.d
@@ -8,7 +8,7 @@ import gland.util;
 import gland.win;
 import gland.gl;
 
-immutable char* vs_shader = "
+immutable char* vs_shader = q{
 	#version 330 core
 
 	layout (location = 0) in vec2 position;
@@ -21,9 +21,9 @@ immutable char* vs_shader = "
 		gl_Position = vec4(position + offset, 0.0, 1.0);
 		v_colour = colour;
 	}
-";
+};
 
-immutable char* fs_shader = "
+immutable char* fs_shader = q{
 	#version 330 core
 
 	in vec3 v_colour;
@@ -32,9 +32,7 @@ immutable char* fs_shader = "
 	void main() {
 		f_colour = vec4(v_colour, 1.0);
 	}
-";
-
-alias Mat4f = float[4][4];
+};
 
 alias InstanceShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [
@@ -45,10 +43,8 @@ alias InstanceShader = Shader!(
 );
 
 struct Vertex2f3f {
-
 	float[2] position;
 	float[3] colour;
-
 } // Vertex2f3f
 
 @(DrawType.DrawArraysInstanced)

--- a/examples/marching-squares/source/app.d
+++ b/examples/marching-squares/source/app.d
@@ -8,7 +8,7 @@ import gland.util;
 import gland.win;
 import gland.gl;
 
-immutable char* ms_vs = "
+immutable char* ms_vs = q{
 	#version 330 core
 
 	layout (location = 0) in vec2 position;
@@ -17,9 +17,9 @@ immutable char* ms_vs = "
 		gl_Position = vec4(position, 0.0, 1.0);
 	}
 
-";
+};
 
-immutable char* ms_gs = "
+immutable char* ms_gs = q{
 	#version 330 core
 
 	layout (points) in;
@@ -502,9 +502,9 @@ immutable char* ms_gs = "
 
 	}
 
-";
+};
 
-immutable char* ms_fs = "
+immutable char* ms_fs = q{
 	#version 330 core
 
 	in vec3 gs_colour;
@@ -514,7 +514,7 @@ immutable char* ms_fs = "
 	void main() {
 		f_colour = gs_colour;
 	}
-";
+};
 
 alias Vec2f = float[2];
 alias Mat4f = float[4][4];
@@ -575,7 +575,7 @@ struct MapData {
 
 alias MapVao = VertexArrayT!MapData;
 
-immutable char* ts_vs = "
+immutable char* ts_vs = q{
 	#version 330 core
 
 	layout (location = 0) in vec2 position;
@@ -587,9 +587,9 @@ immutable char* ts_vs = "
 		gl_Position = vec4(position, 0.0, 1.0);
 		tex_coord = uv;
 	}
-";
+};
 
-immutable char* ts_fs = "
+immutable char* ts_fs = q{
 	#version 330 core
 
 	in vec2 tex_coord;
@@ -601,7 +601,7 @@ immutable char* ts_fs = "
 	void main() {
 		f_colour = vec4(texture2D(diffuse, tex_coord).r, 0.0, 0.0, 1.0);
 	}
-";
+};
 
 struct TextureUniform {
 

--- a/examples/marching-squares/source/app.d
+++ b/examples/marching-squares/source/app.d
@@ -550,10 +550,17 @@ immutable Height[GridSize][GridSize] grid = [
 
 ];
 
+struct MapUniform {
+
+	@TextureUnit(0)
+	Texture2D* texture_map;
+
+} // MapUniform
+
 alias MapShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.GeometryShader, ShaderType.FragmentShader], [
 		AttribTuple("position", 0)
-	], Texture*, "texture_map"
+	], MapUniform
 );
 
 @(DrawType.DrawArrays)
@@ -596,11 +603,18 @@ immutable char* ts_fs = "
 	}
 ";
 
+struct TextureUniform {
+
+	@TextureUnit(0)
+	Texture2D* diffuse;
+
+} // TextureUniform
+
 alias TextureShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [
 		AttribTuple("position", 0),
 		AttribTuple("uv", 1)
-	], Texture*, "diffuse"
+	], TextureUniform
 );
 
 struct Vertex2f2f {
@@ -620,7 +634,7 @@ struct VertexData {
 
 alias TextureVao = VertexArrayT!VertexData;
 
-Texture generateMapTexture(ref in Height[GridSize][GridSize] cells) {
+Texture2D generateMapTexture(ref in Height[GridSize][GridSize] cells) {
 
 	TextureParams params = {
 		internal_format : InternalTextureFormat.R8,
@@ -631,8 +645,8 @@ Texture generateMapTexture(ref in Height[GridSize][GridSize] cells) {
 		mipmap_max_level : 0
 	};
 
-	Texture new_texture;
-	auto texture_result = Texture.create(new_texture, cast(ubyte*)cells.ptr, GridSize, GridSize, params);
+	Texture2D new_texture;
+	auto texture_result = Texture2D.create(new_texture, cast(ubyte*)cells.ptr, GridSize, GridSize, params);
 
 	return new_texture;
 
@@ -645,6 +659,7 @@ void main() {
 
 	Window window;
 	auto result = Window.create(window, 640, 480);
+	auto device = Renderer.createDevice(&window.width, &window.height, &window.present);
 
 	final switch (result) with (Window.Error) {
 
@@ -661,12 +676,12 @@ void main() {
 	}
 
 	// framebuffer texture
-	Texture fb_texture;
+	Texture2D fb_texture;
 	TextureParams params = {
 		internal_format : InternalTextureFormat.RGB,
 		pixel_format : PixelFormat.RGB
 	};
-	auto fb_tex_result = Texture.create(fb_texture, null, window.width, window.height, params);
+	auto fb_tex_result = Texture2D.create(fb_texture, cast(ubyte*)null, window.width, window.height, params);
 
 	// create fb with texture	
 	SimpleFramebuffer sfb;
@@ -735,13 +750,16 @@ void main() {
 		// default state, holds all OpenGL state params like blend state etc to be use for given draw call
 		DrawParams draw_params = {};
 
-		Renderer.clearColour(sfb, 0xffa500);
-		Renderer.draw(sfb, map_shader, vao, draw_params, &map_texture);
+		sfb.clearColour(0xffa500);
+
+		auto map_uniform = MapUniform(&map_texture);
+		sfb.draw(map_shader, vao, draw_params, map_uniform);
 
 		// cornflower blue, of course
-		Renderer.draw(tex_shader, tex_vao, draw_params, &fb_texture);
+		auto tex_uniform = TextureUniform(&fb_texture);
+		device.draw(tex_shader, tex_vao, draw_params, tex_uniform);
 
-		window.present();
+		device.present();
 
 	}
 

--- a/examples/memory-saver/source/app.d
+++ b/examples/memory-saver/source/app.d
@@ -8,7 +8,7 @@ import gland.util;
 import gland.win;
 import gland.gl;
 
-immutable char* vs_shader = "
+immutable char* vs_shader = q{
 	#version 330
 
 	uniform mat4 model;
@@ -22,9 +22,9 @@ immutable char* vs_shader = "
 		gl_Position = model * vec4(position, 0.0, 1.0);
 		v_colour = colour;
 	}
-";
+};
 
-immutable char* fs_shader = "
+immutable char* fs_shader = q{
 	#version 330
 
 	in vec3 v_colour;
@@ -33,9 +33,9 @@ immutable char* fs_shader = "
 	void main() {
 		f_colour = vec4(v_colour, 1.0);
 	}
-";
+};
 
-immutable char* tex_vs_shader = "
+immutable char* tex_vs_shader = q{
     #version 330 core
 
     layout (location = 0) in vec2 position;
@@ -47,9 +47,9 @@ immutable char* tex_vs_shader = "
         gl_Position = vec4(position, 0.0, 1.0);
         tex_coord = uv;
     }
-";
+};
 
-immutable char* tex_fs_shader = "
+immutable char* tex_fs_shader = q{
     #version 330 core
 
     in vec2 tex_coord;
@@ -61,11 +61,13 @@ immutable char* tex_fs_shader = "
     void main() {
         f_colour = texture2D(diffuse, tex_coord);
     }
-";
+};
+
+alias Mat4f = float[4][4];
 
 struct TriangleUniform {
 
-	float[4][4][] model;
+	Mat4f[] model;
 
 } // TriangleUniform
 
@@ -79,7 +81,7 @@ alias TriangleShader = Shader!(
 struct TextureUniform {
 
 	@TextureUnit(0)
-	Texture* diffuse;
+	Texture2D* diffuse;
 
 } // TextureUniform
 
@@ -159,9 +161,9 @@ void main() {
 	int texture_h = window.height / 8;
 
 	// create texture to render to
-	Texture framebuffer_texture;
+	Texture2D framebuffer_texture;
 	TextureParams tex_params = {};
-	auto texture_result = Texture.create(framebuffer_texture, null, texture_w, texture_h, tex_params);
+	auto texture_result = Texture2D.create(framebuffer_texture, cast(ubyte*)null, texture_w, texture_h, tex_params);
 	
 	// create a frame buffer from this texture
 	SimpleFramebuffer frame_buffer;
@@ -248,7 +250,6 @@ void main() {
 		// now render given texture, woo!
 		auto uniform_data = TextureUniform(&framebuffer_texture);
 		device.draw(texture_shader, rect_vao, params, uniform_data);
-
 
 		device.present();
 

--- a/examples/memory-saver/source/app.d
+++ b/examples/memory-saver/source/app.d
@@ -250,7 +250,7 @@ void main() {
 		device.draw(texture_shader, rect_vao, params, uniform_data);
 
 
-		window.present();
+		device.present();
 
 	}
 

--- a/examples/textured-rectangle/source/app.d
+++ b/examples/textured-rectangle/source/app.d
@@ -8,7 +8,7 @@ import gland.util;
 import gland.win;
 import gland.gl;
 
-immutable char* vs_shader = "
+immutable char* vs_shader = q{
 	#version 330 core
 
 	layout (location = 0) in vec2 position;
@@ -22,9 +22,9 @@ immutable char* vs_shader = "
 		gl_Position = vec4(position + offset, 0.0, 1.0);
 		tex_coord = uv;
 	}
-";
+};
 
-immutable char* fs_shader = "
+immutable char* fs_shader = q{
 	#version 330 core
 
 	in vec2 tex_coord;
@@ -36,7 +36,7 @@ immutable char* fs_shader = "
 	void main() {
 		f_colour = texture2D(diffuse, tex_coord);
 	}
-";
+};
 
 alias Mat4f = float[4][4];
 
@@ -132,7 +132,7 @@ void main() {
 		internal_format : InternalTextureFormat.R8,
 		pixel_format : PixelFormat.Red
 	};
-	auto texture_result = Texture2D.create(texture, texture_data[], sections, sections, texture_params);
+	auto texture_result = Texture2D.create(texture, texture_data.ptr, sections, sections, texture_params);
 
 	// declare vertex data
 	Vertex2f2f[6] vertices = [

--- a/examples/textured-rectangle/source/app.d
+++ b/examples/textured-rectangle/source/app.d
@@ -45,7 +45,7 @@ struct TextureUniform {
 	float[2] offset;
 
 	@TextureUnit(0)
-	Texture* diffuse;
+	Texture2D* diffuse;
 
 } // TextureUniform
 
@@ -82,7 +82,7 @@ void main() {
 
 	Window window;
 	auto result = Window.create(window, 640, 480);
-	auto device = Renderer.createDevice(&window.width, &window.height);
+	auto device = Renderer.createDevice(&window.width, &window.height, &window.present);
 
 	final switch (result) with (Window.Error) {
 
@@ -125,14 +125,14 @@ void main() {
 
 	// create a simple checkered texture
 
-	Texture texture;
+	Texture2D texture;
 	immutable uint sections = 8;
 	auto texture_data = checkerboard!sections(255, 0);
 	TextureParams texture_params = {
 		internal_format : InternalTextureFormat.R8,
 		pixel_format : PixelFormat.Red
 	};
-	auto texture_result = Texture.create(texture, texture_data[], sections, sections, texture_params);
+	auto texture_result = Texture2D.create(texture, texture_data[], sections, sections, texture_params);
 
 	// declare vertex data
 	Vertex2f2f[6] vertices = [

--- a/examples/textured-rectangle/source/app.d
+++ b/examples/textured-rectangle/source/app.d
@@ -170,7 +170,7 @@ void main() {
 		auto uniform_data = TextureUniform([-0.5, -0.5], &texture);
 		device.draw(texture_shader, vao, params, uniform_data);
 
-		window.present();
+		device.present();
 
 	}
 

--- a/examples/triangle/source/app.d
+++ b/examples/triangle/source/app.d
@@ -8,7 +8,7 @@ import gland.util;
 import gland.win;
 import gland.gl;
 
-immutable char* vs_shader = "
+immutable char* vs_shader = q{
 	#version 330
 
 	layout (location = 0) in vec2 position;
@@ -20,9 +20,9 @@ immutable char* vs_shader = "
 		gl_Position = vec4(position, 0.0, 1.0);
 		v_colour = colour;
 	}
-";
+};
 
-immutable char* fs_shader = "
+immutable char* fs_shader = q{
 	#version 330
 
 	in vec3 v_colour;
@@ -31,9 +31,7 @@ immutable char* fs_shader = "
 	void main() {
 		f_colour = vec4(v_colour, 1.0);
 	}
-";
-
-alias Mat4f = float[4][4];
+};
 
 alias TriangleShader = Shader!(
 	[ShaderType.VertexShader, ShaderType.FragmentShader], [

--- a/examples/triangle/source/app.d
+++ b/examples/triangle/source/app.d
@@ -43,10 +43,8 @@ alias TriangleShader = Shader!(
 );
 
 struct Vertex2f3f {
-
 	float[2] position;
 	float[3] colour;
-
 } // Vertex2f3f
 
 @(DrawType.DrawArrays)
@@ -68,7 +66,7 @@ void main() {
 
 	Window window;
 	auto result = Window.create(window, 640, 480);
-	auto device = Renderer.createDevice(&window.width, &window.height);
+	auto device = Renderer.createDevice(&window.width, &window.height, &window.present);
 
 	final switch (result) with (Window.Error) {
 
@@ -123,7 +121,7 @@ void main() {
 		device.clearColour(0x428bca);
 		device.draw(triangle_shader, vao, params);
 
-		window.present();
+		device.present();
 
 	}
 

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -641,8 +641,14 @@ bool hasDepth(TextureType type) {
 
 template TypeToGLTexture(T) {
 
+	import std.string : format;
+
 	static if (is (T : Texture2D)) {
 		enum TypeToGLTexture = TextureType.Texture2D;
+	} else static if (is (T : Texture3D)) {
+		enum TypeToGLTexture = TextureType.Texture3D;
+	} else {
+		static assert(0, format("unsupported texture type: %s", T.stringof));
 	}
 
 } // TypeToGLTexture
@@ -798,10 +804,14 @@ struct Texture2D {
 
 	}
 
+	@disable this(this);
+	@disable ref typeof(this) opAssign(ref typeof(this));
+
 	static auto create(DataType)(ref typeof(this) texture, in DataType[] texture_data, int width, int height, ref TextureParams params) {
 
 		texture.width_ = width;
 		texture.height_ = height;
+
 		return Texture.create(texture, texture_data.ptr, params);
 
 	} // create
@@ -820,9 +830,33 @@ struct Texture3D {
 
 		Texture texture_;
 
+		uint width_;
+		uint height_;
+
 	}
 
 	alias texture_ this;
+
+	@property
+	nothrow @nogc const {
+
+		uint width() { return width_; }
+		uint height() { return height_; }
+
+	}
+
+	@disable this(this);
+	@disable ref typeof(this) opAssign(ref typeof(this));
+
+	static auto create(DataType)(ref typeof(this) texture, in DataType[] texture_data, int width, int height, int depth, ref TextureParams params) {
+
+		texture.width_ = width;
+		texture.height_ = height;
+		texture.depth_ = depth;
+
+		return Texture.create(texture, texture_data.ptr, params);
+
+	} // create
 
 } // Texture3D
 
@@ -836,6 +870,9 @@ struct Texture1DArray {
 
 	alias texture_ this;
 
+	@disable this(this);
+	@disable ref typeof(this) opAssign(ref typeof(this));
+
 } // Texture1DArray
 
 struct Texture2DArray {
@@ -847,6 +884,9 @@ struct Texture2DArray {
 	}
 
 	alias texture_ this;
+
+	@disable this(this);
+	@disable ref typeof(this) opAssign(ref typeof(this));
 
 } // Texture2DArray
 

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -808,12 +808,14 @@ struct Texture2D {
 	@disable this(this);
 	@disable ref typeof(this) opAssign(ref typeof(this));
 
+	nothrow @nogc
 	static auto create(DataType)(ref typeof(this) texture, in DataType[] texture_data, int width, int height, ref TextureParams params) {
 
 		return Texture2D.create(texture, texture_data.ptr, params);
 
 	} // create
 
+	nothrow @nogc
 	static auto create(DataType)(ref typeof(this) texture, in DataType* texture_data, int width, int height, ref TextureParams params) {
 
 		texture.width_ = width;
@@ -823,6 +825,15 @@ struct Texture2D {
 
 	} // create
 
+	nothrow @nogc
+	void update(int x_offset, int y_offset, int width, int height, in ubyte* bytes) {
+
+		Renderer.bindTexture(texture_.handle_, 0);
+		glTexSubImage2D(texture_.texture_type_, 0, x_offset, y_offset, width, height, texture_.pixel_format_, TypeToGL!ubyte, bytes);
+
+	} // update
+
+	nothrow @nogc
 	SimpleFramebuffer.Error asSurface(ref SimpleFramebuffer buffer, bool with_depth_buffer) {
 
 		return SimpleFramebuffer.create(buffer, this, with_depth_buffer);

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -1528,7 +1528,7 @@ mixin template RendererStateVars() {
 	bool line_smooth;
 
 	//GL_MULTISAMPLE
-	// ... TODO
+	bool multisample;
 
 	//GL_SHADE_MODEL
 	ShadingType shading_type;
@@ -1686,7 +1686,8 @@ private:
 				GL_CULL_FACE, cull_face,
 				GL_DEPTH_TEST, depth_test,
 				GL_STENCIL_TEST, stencil_test,
-				GL_SCISSOR_TEST, scissor_test
+				GL_SCISSOR_TEST, scissor_test,
+				GL_MULTISAMPLE, multisample
 			);
 
 			/**
@@ -2047,6 +2048,7 @@ void draw_with_offset(ShaderType, VertexArrayType, UniformTypes...)(ref ShaderTy
 	Renderer.setState(GL_DEPTH_TEST, params.state.depth_test);
 	Renderer.setState(GL_STENCIL_TEST, params.state.stencil_test);
 	Renderer.setState(GL_SCISSOR_TEST, params.state.scissor_test);
+	Renderer.setState(GL_MULTISAMPLE, params.state.multisample);
 
 	// actions after aforemented glDisable/glEnable
 	if (Renderer.scissor_test) {

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -809,9 +809,16 @@ struct Texture2D {
 	@disable ref typeof(this) opAssign(ref typeof(this));
 
 	nothrow @nogc
+	static auto create(DataType)(ref typeof(this) texture, int width, int height, ref TextureParams params) {
+
+		return Texture2D.create(texture, cast(DataType*)null, width, height, params);
+
+	} // create
+
+	nothrow @nogc
 	static auto create(DataType)(ref typeof(this) texture, in DataType[] texture_data, int width, int height, ref TextureParams params) {
 
-		return Texture2D.create(texture, texture_data.ptr, params);
+		return Texture2D.create(texture, texture_data.ptr, width, height, params);
 
 	} // create
 

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -663,10 +663,8 @@ struct Texture {
 
 	@property
 	const @nogc nothrow {
-
 		GLuint handle() { return handle_; }
 		TextureType type() { return texture_type_; }
-
 	}
 
 	enum Error {
@@ -1874,8 +1872,7 @@ void draw_with_offset(ShaderType, VertexArrayType, UniformTypes...)(ref ShaderTy
 	Renderer.bindVertexArray(vao);
 	Renderer.useProgram(shader.handle);
 
-	static assert(!__traits(compiles, ShaderType.UniformStruct) && UniformTypes.length == 0
-			|| is(UniformTypes[0] == ShaderType.UniformStruct),
+	static assert(!__traits(compiles, ShaderType.UniformStruct) && UniformTypes.length == 0 || is(UniformTypes[0] == ShaderType.UniformStruct),
 			"uniform struct was either omitted on draw call or added when unnecessary!");
 
 	static if (UniformTypes.length == 1)

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -777,9 +777,29 @@ struct Texture1D {
 
 		Texture texture_;
 
+		uint width_;
+
 	}
 
 	alias texture_ this;
+
+	@property
+	nothrow @nogc const {
+
+		uint width() { return width_; }
+		GLuint handle() { return texture_.handle; }
+
+	}
+
+	@disable this(this);
+	@disable ref typeof(this) opAssign(ref typeof(this));
+
+	nothrow @nogc
+	static auto create(DataType)(ref Texture1D texture, in DataType* texture_data, int width, ref TextureParams params) {
+
+		return Texture.create(texture, texture_data, params);
+
+	} // create
 
 } // Texture1D
 
@@ -809,21 +829,21 @@ struct Texture2D {
 	@disable ref typeof(this) opAssign(ref typeof(this));
 
 	nothrow @nogc
-	static auto create(DataType)(ref typeof(this) texture, int width, int height, ref TextureParams params) {
+	static auto create(DataType)(ref Texture2D texture, int width, int height, ref TextureParams params) {
 
 		return Texture2D.create(texture, cast(DataType*)null, width, height, params);
 
 	} // create
 
 	nothrow @nogc
-	static auto create(DataType)(ref typeof(this) texture, in DataType[] texture_data, int width, int height, ref TextureParams params) {
+	static auto create(DataType)(ref Texture2D texture, in DataType[] texture_data, int width, int height, ref TextureParams params) {
 
 		return Texture2D.create(texture, texture_data.ptr, width, height, params);
 
 	} // create
 
 	nothrow @nogc
-	static auto create(DataType)(ref typeof(this) texture, in DataType* texture_data, int width, int height, ref TextureParams params) {
+	static auto create(DataType)(ref Texture2D texture, in DataType* texture_data, int width, int height, ref TextureParams params) {
 
 		texture.width_ = width;
 		texture.height_ = height;
@@ -874,7 +894,7 @@ struct Texture3D {
 	@disable this(this);
 	@disable ref typeof(this) opAssign(ref typeof(this));
 
-	static auto create(DataType)(ref typeof(this) texture, in DataType[] texture_data, int width, int height, int depth, ref TextureParams params) {
+	static auto create(DataType)(ref Texture3D texture, in DataType[] texture_data, int width, int height, int depth, ref TextureParams params) {
 
 		texture.width_ = width;
 		texture.height_ = height;

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -327,7 +327,7 @@ alias AttribTuple = Tuple!(string, "identifier", int, "offset");
 struct Shader(immutable ShaderType[] shader_types, immutable AttribTuple[] attributes, UniformStructType...) {
 
 	import std.string : format;
-	static assert(UniformStructType.length == 0 || UniformStructType.length == 1);
+	static assert(UniformStructType.length == 0 || UniformStructType.length == 1, "expected either no uniform struct, or a single struct.");
 
 	static if (UniformStructType.length == 1) {
 		alias UniformStruct = UniformStructType[0];
@@ -801,6 +801,7 @@ struct Texture2D {
 
 		uint width() { return width_; }
 		uint height() { return height_; }
+		GLuint handle() { return texture_.handle; }
 
 	}
 
@@ -809,10 +810,16 @@ struct Texture2D {
 
 	static auto create(DataType)(ref typeof(this) texture, in DataType[] texture_data, int width, int height, ref TextureParams params) {
 
+		return Texture2D.create(texture, texture_data.ptr, params);
+
+	} // create
+
+	static auto create(DataType)(ref typeof(this) texture, in DataType* texture_data, int width, int height, ref TextureParams params) {
+
 		texture.width_ = width;
 		texture.height_ = height;
 
-		return Texture.create(texture, texture_data.ptr, params);
+		return Texture.create(texture, texture_data, params);
 
 	} // create
 

--- a/source/gland/gl.d
+++ b/source/gland/gl.d
@@ -796,7 +796,7 @@ struct Texture2D {
 
 	alias texture_ this;
 
-	@property 
+	@property
 	nothrow @nogc const {
 
 		uint width() { return width_; }
@@ -860,6 +860,7 @@ struct Texture3D {
 
 		uint width() { return width_; }
 		uint height() { return height_; }
+		GLuint handle() { return texture_.handle; }
 
 	}
 
@@ -876,6 +877,14 @@ struct Texture3D {
 
 	} // create
 
+	nothrow @nogc
+	void update(int x_offset, int y_offset, int z_offset, int width, int height, int depth, in ubyte* bytes) {
+
+		Renderer.bindTexture(texture_.handle_, 0);
+		glTexSubImage3D(texture_.texture_type_, 0, x_offset, y_offset, z_offset, width, height, depth, texture_.pixel_format_, TypeToGL!ubyte, bytes);
+
+	} // update
+
 } // Texture3D
 
 struct Texture1DArray {
@@ -884,12 +893,32 @@ struct Texture1DArray {
 
 		Texture texture_;
 
+		uint width_;
+		uint height_;
+
 	}
 
 	alias texture_ this;
 
+	@property
+	nothrow @nogc const {
+
+		uint width() { return width_; }
+		uint height() { return height_; }
+		GLuint handle() { return texture_.handle; }
+
+	}
+
 	@disable this(this);
 	@disable ref typeof(this) opAssign(ref typeof(this));
+
+	nothrow @nogc
+	void update(int x_offset, int y_offset, int z_offset, int width, int height, int depth, in ubyte* bytes) {
+
+		Renderer.bindTexture(texture_.handle_, 0);
+		glTexSubImage2D(texture_.texture_type_, 0, x_offset, y_offset, width, height, texture_.pixel_format_, TypeToGL!ubyte, bytes);
+
+	} // update
 
 } // Texture1DArray
 
@@ -899,12 +928,34 @@ struct Texture2DArray {
 
 		Texture texture_;
 
+		uint width_;
+		uint height_;
+		uint depth_;
+
 	}
 
 	alias texture_ this;
 
+	@property
+	nothrow @nogc const {
+
+		uint width() { return width_; }
+		uint height() { return height_; }
+		uint depth() { return depth_; }
+		GLuint handle() { return texture_.handle; }
+
+	}
+
 	@disable this(this);
 	@disable ref typeof(this) opAssign(ref typeof(this));
+
+	nothrow @nogc
+	void update(int x_offset, int y_offset, int z_offset, int width, int height, int depth, in ubyte* bytes) {
+
+		Renderer.bindTexture(texture_.handle_, 0);
+		glTexSubImage3D(texture_.texture_type_, 0, x_offset, y_offset, z_offset, width, height, depth, texture_.pixel_format_, TypeToGL!ubyte, bytes);
+
+	} // update
 
 } // Texture2DArray
 


### PR DESCRIPTION
Basic rework of how textures are handled in the library, now we have separate types for each kind of texture, with a single internal base texture type which can be passed around inside the library, while the Texture1D/etc types are exposed to the user.

Also updated all the examples to build with the changes.

Later on, more changes like reading from textures, copying textures etc will come in as well as they would be of interest to users. Pixel buffers are next, probably.
